### PR TITLE
Allow null to be returned from TVDb API

### DIFF
--- a/src/Model/BasicSeries.php
+++ b/src/Model/BasicSeries.php
@@ -45,7 +45,7 @@ class BasicSeries
     /**
      * The URL to the banner of the serie.
      *
-     * @var string
+     * @var string|null
      */
     public $banner;
     /**
@@ -81,13 +81,13 @@ class BasicSeries
     /**
      * The slug of the serie.
      *
-     * @var string
+     * @var string|null
      */
     public $slug;
     /**
      * The status of the serie.
      *
-     * @var string
+     * @var string|null
      */
     public $status;
 }


### PR DESCRIPTION
The TVDB site started returning null on many endpoints, so we need to allow those now.