### PR TITLE
Fix bad image_url and primary_language parameters

### DIFF
--- a/src/Model/SearchResult.php
+++ b/src/Model/SearchResult.php
@@ -89,7 +89,7 @@ class SearchResult
      *
      * @var string
      */
-    public string $imageUrl;
+    public string $image_url;
     /**
      * The name.
      *

--- a/src/Model/SearchResult.php
+++ b/src/Model/SearchResult.php
@@ -131,7 +131,7 @@ class SearchResult
      *
      * @var string
      */
-    public string $primaryLanguage;
+    public string $primary_language;
     /**
      * Original type
      *


### PR DESCRIPTION
TVDB returns this as 'image_url' and 'primary_language'm changing it in SearchResult makes it show up in searches.